### PR TITLE
chore: replace resolveZoneFileToProfile from blockstack SDK

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2150,6 +2150,178 @@
         "@stacks/common": "^1.0.0-beta.20"
       }
     },
+    "@stacks/profile": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@stacks/profile/-/profile-3.1.0.tgz",
+      "integrity": "sha512-XkuuzRVLXn45+4o8JHJ9RsWQn9Vahm2vBnbFHY/f0FAywK+D06VBpse9qj9ZbtsYtolB1pjdy+6kLsewPiBNIw==",
+      "requires": {
+        "@stacks/common": "^3.0.0",
+        "@stacks/network": "^3.0.0",
+        "@stacks/transactions": "^3.1.0",
+        "jsontokens": "^3.0.0",
+        "schema-inspector": "^2.0.1",
+        "zone-file": "^2.0.0-beta.3"
+      },
+      "dependencies": {
+        "@stacks/common": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@stacks/common/-/common-3.0.0.tgz",
+          "integrity": "sha512-48zCfU8zX0r8b8eP2n6l/bicAiFQyHPTMimdBwot9JqgzWW8WqGpcZD3qSZIwV0tBHD5LMLxNY018OqQIH6c5Q==",
+          "requires": {
+            "@types/node": "^14.14.43",
+            "bn.js": "^4.12.0",
+            "buffer": "^6.0.3",
+            "cross-fetch": "^3.1.4"
+          }
+        },
+        "@stacks/network": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/@stacks/network/-/network-3.0.0.tgz",
+          "integrity": "sha512-JJbQqCN8JlJz8bZu7enW9OBkMG5vEfHnp0rdY6AEp3Gzq9JsFD1C0BbbhMv/IqmCcLuAGmMwo+2C1NKCDJBUdQ==",
+          "requires": {
+            "@stacks/common": "^3.0.0"
+          }
+        },
+        "@stacks/transactions": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-3.1.0.tgz",
+          "integrity": "sha512-K+E7Ip4AUVqV9cluZ3IMPueBodgfkM7JG4y/cQsvj04+BypD81eYIQKGdDte3XDe+MbVBnXJJRySu7bMFrjIiA==",
+          "requires": {
+            "@stacks/common": "^3.0.0",
+            "@stacks/network": "^3.0.0",
+            "@types/bn.js": "^4.11.6",
+            "@types/elliptic": "^6.4.12",
+            "@types/node": "^14.14.43",
+            "@types/randombytes": "^2.0.0",
+            "@types/sha.js": "^2.4.0",
+            "bn.js": "^4.12.0",
+            "c32check": "^1.1.3",
+            "cross-fetch": "^3.1.4",
+            "elliptic": "^6.5.4",
+            "lodash": "^4.17.20",
+            "randombytes": "^2.1.0",
+            "ripemd160-min": "^0.0.6",
+            "sha.js": "^2.4.11",
+            "smart-buffer": "^4.1.0"
+          }
+        },
+        "@types/node": {
+          "version": "14.18.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.9.tgz",
+          "integrity": "sha512-j11XSuRuAlft6vLDEX4RvhqC0KxNxx6QIyMXNb0vHHSNPXTPeiy3algESWmOOIzEtiEL0qiowPU3ewW9hHVa7Q=="
+        },
+        "async": {
+          "version": "2.6.3",
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.3.tgz",
+          "integrity": "sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==",
+          "requires": {
+            "lodash": "^4.17.14"
+          }
+        },
+        "bn.js": {
+          "version": "4.12.0",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.0.tgz",
+          "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
+        },
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        },
+        "c32check": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/c32check/-/c32check-1.1.3.tgz",
+          "integrity": "sha512-ADADE/PjAbJRlwpG3ShaOMbBUlJJZO7xaYSRD5Tub6PixQlgR4s36y9cvMf/YRGpkqX+QOxIdMw216iC320q9A==",
+          "requires": {
+            "base-x": "^3.0.8",
+            "buffer": "^5.6.0",
+            "cross-sha256": "^1.2.0"
+          },
+          "dependencies": {
+            "buffer": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+              "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+              }
+            }
+          }
+        },
+        "cross-fetch": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+          "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+          "requires": {
+            "node-fetch": "2.6.7"
+          }
+        },
+        "cross-sha256": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/cross-sha256/-/cross-sha256-1.2.0.tgz",
+          "integrity": "sha512-KViLNMDZKV7jwFqjFx+rNhG26amnFYYQ0S+VaFlVvpk8tM+2XbFia/don/SjGHg9WQxnFVi6z64CGPuF3T+nNw==",
+          "requires": {
+            "buffer": "^5.6.0"
+          },
+          "dependencies": {
+            "buffer": {
+              "version": "5.7.1",
+              "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+              "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+              "requires": {
+                "base64-js": "^1.3.1",
+                "ieee754": "^1.1.13"
+              }
+            }
+          }
+        },
+        "elliptic": {
+          "version": "6.5.4",
+          "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.4.tgz",
+          "integrity": "sha512-iLhC6ULemrljPZb+QutR5TQGB+pdW6KGD5RSegS+8sorOZT+rdQFbsQFJgvN3eRqNALqJer4oQ16YvJHlU8hzQ==",
+          "requires": {
+            "bn.js": "^4.11.9",
+            "brorand": "^1.1.0",
+            "hash.js": "^1.0.0",
+            "hmac-drbg": "^1.0.1",
+            "inherits": "^2.0.4",
+            "minimalistic-assert": "^1.0.1",
+            "minimalistic-crypto-utils": "^1.0.1"
+          }
+        },
+        "inherits": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+        },
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        },
+        "schema-inspector": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/schema-inspector/-/schema-inspector-2.0.1.tgz",
+          "integrity": "sha512-lqR4tOVfoqf9Z8cgX/zvXuWPnTWCqrc4WSgeSPDDc1bWbMABaqdSTY98xj7iRKHOIRtKjc4M8EWCgUu5ASlHkg==",
+          "requires": {
+            "async": "~2.6.3"
+          }
+        },
+        "zone-file": {
+          "version": "2.0.0-beta.3",
+          "resolved": "https://registry.npmjs.org/zone-file/-/zone-file-2.0.0-beta.3.tgz",
+          "integrity": "sha512-6tE3PSRcpN5lbTTLlkLez40WkNPc9vw/u1J2j6DBiy0jcVX48nCkWrx2EC+bWHqC2SLp069Xw4AdnYn/qp/W5g=="
+        }
+      }
+    },
     "@stacks/transactions": {
       "version": "1.0.0-beta.20",
       "resolved": "https://registry.npmjs.org/@stacks/transactions/-/transactions-1.0.0-beta.20.tgz",
@@ -8945,6 +9117,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
+    },
     "trim-newlines": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
@@ -9243,6 +9420,20 @@
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
         "extsprintf": "^1.2.0"
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "@promster/express": "^3.2.0",
     "@promster/server": "^3.2.0",
     "@stacks/network": "^1.0.0-beta.20",
+    "@stacks/profile": "^3.1.0",
     "@stacks/transactions": "^1.0.0-beta.20",
     "async-lock": "^1.1.3",
     "bitcoinjs-lib": "^3.3.2",

--- a/src/lookups.js
+++ b/src/lookups.js
@@ -1,5 +1,6 @@
-import { config as bskConfig, validateProofs, resolveZoneFileToProfile } from 'blockstack'
+import { config as bskConfig, validateProofs } from 'blockstack'
 import { validateStacksAddress } from '@stacks/transactions'
+import { resolveZoneFileToProfile } from '@stacks/profile'
 import fetch from 'node-fetch'
 
 import logger from 'winston'


### PR DESCRIPTION
## Description

While browsing the repo I found this function that can be extracted from the blockstack package. I will submit other pull requests if I find other parts that can be migrated easily.

## Type of Change

Code change.

## Does this introduce a breaking change?

No

## Checklist
- [ ] Code is commented where needed
- [ ] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [ ] Changelog is updated
- [ ] Tag 1 of @wileyj or @CharlieC3 
