### PR TITLE
fix: update API paths to use API domain

### DIFF
--- a/src/lookups.js
+++ b/src/lookups.js
@@ -7,7 +7,7 @@ import logger from 'winston'
 export async function isSubdomainRegistered(fullyQualifiedAddress: String) {
 
   try {
-    const nameInfoUrl = bskConfig.network.coreApiUrl + '/v1/names/' + fullyQualifiedAddress
+    const nameInfoUrl = bskConfig.network.blockstackAPIUrl + '/v1/names/' + fullyQualifiedAddress
     const nameInfoRequest = await fetch(nameInfoUrl)
     const { status } = nameInfoRequest
     if (status == 200) {

--- a/src/operations.js
+++ b/src/operations.js
@@ -171,7 +171,7 @@ export async function submitUpdate(
     throw new Error('Invalid domain name')
   }
 
-  const nameInfoUrl = bskConfig.network.coreApiUrl + '/v1/names/' + domainName
+  const nameInfoUrl = bskConfig.network.blockstackAPIUrl + '/v1/names/' + domainName
   const nameInfoRequest = await fetch(nameInfoUrl)
   const nameInfo = await nameInfoRequest.json()
 
@@ -267,7 +267,7 @@ export async function checkTransactions(
       if (!tx.blockHeight || tx.blockHeight <= 0) {
         // const txInfo = await bskConfig.network.getTransactionInfo(tx.txHash)
         const url = new URL(
-          bskConfig.network.coreApiUrl + `/extended/v1/tx/0x${tx.txHash}`
+          bskConfig.network.blockstackAPIUrl + `/extended/v1/tx/0x${tx.txHash}`
         );
         const httpRequest = await fetch(url);
         const reqText = await httpRequest.text();

--- a/tests/src/index.js
+++ b/tests/src/index.js
@@ -9,6 +9,7 @@ import { StacksMainnet } from '@stacks/network'
 nock.disableNetConnect()
 
 bskConfig.network = new StacksMainnet()
+bskConfig.network.blockstackAPIUrl = bskConfig.network.coreApiUrl
 
 unitTestLookups()
 unitTestOperations()


### PR DESCRIPTION
This updates any endpoints which use a Stacks Blockchain API path to call the correctly configured endpoint for the service. Previously, this bug was hidden because the Stacks Blockchain API and Stacks Core RPC service had to be configured on the same domain. Now that they can be configured on separate domains since release 1.3.0, this bug popped up.

I've deployed and tested this patch and it appears to be running the same as it were at version 1.2.1.